### PR TITLE
Implement password reset functionality

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -55,6 +55,33 @@ class AppState extends ChangeNotifier {
     notifyListeners();
   }
   
+  bool userExists(String username) {
+    return _users.any((user) => user.username == username);
+  }
+  
+  bool resetPassword(String username, String newPassword) {
+    final userIndex = _users.indexWhere((user) => user.username == username);
+    if (userIndex != -1) {
+      // Create a new user object with the updated password
+      final oldUser = _users[userIndex];
+      final updatedUser = User(
+        id: oldUser.id,
+        username: oldUser.username,
+        password: newPassword,
+      );
+      _users[userIndex] = updatedUser;
+      
+      // If the current user is the one whose password was reset, update the current user reference
+      if (_currentUser?.username == username) {
+        _currentUser = updatedUser;
+      }
+      
+      notifyListeners();
+      return true;
+    }
+    return false;
+  }
+  
   void addPost(String text) {
     if (_currentUser == null) return;
     

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'app_state.dart';
 import 'screens/login_screen.dart';
 import 'screens/create_post_screen.dart';
+import 'screens/password_reset_screen.dart';
 import 'widgets/post_card.dart';
 
 void main() {
@@ -24,6 +25,9 @@ class MyApp extends StatelessWidget {
       home: appState.currentUser == null
           ? const LoginScreen()
           : const HomeScreen(),
+      routes: {
+        '/forgot-password': (context) => const PasswordResetScreen(),
+      },
     );
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@ import 'package:provider/provider.dart';
 import 'app_state.dart';
 import 'screens/login_screen.dart';
 import 'screens/create_post_screen.dart';
-import 'screens/password_reset_screen.dart';
 import 'widgets/post_card.dart';
 
 void main() {
@@ -25,9 +24,6 @@ class MyApp extends StatelessWidget {
       home: appState.currentUser == null
           ? const LoginScreen()
           : const HomeScreen(),
-      routes: {
-        '/forgot-password': (context) => const PasswordResetScreen(),
-      },
     );
   }
 

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -103,6 +103,19 @@ class _LoginScreenState extends State<LoginScreen> {
                     : 'Have an account? Login',
               ),
             ),
+            if (_isLogin) ...[
+              TextButton(
+                onPressed: () {
+                  Navigator.pushNamed(context, '/forgot-password');
+                },
+                child: const Text(
+                  'Forgot Password?',
+                  style: TextStyle(
+                    decoration: TextDecoration.underline,
+                  ),
+                ),
+              ),
+            ],
           ],
         ),
       ),

--- a/lib/screens/password_reset_screen.dart
+++ b/lib/screens/password_reset_screen.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../app_state.dart';
+
+class PasswordResetScreen extends StatefulWidget {
+  const PasswordResetScreen({super.key});
+
+  @override
+  State<PasswordResetScreen> createState() => _PasswordResetScreenState();
+}
+
+class _PasswordResetScreenState extends State<PasswordResetScreen> {
+  final _usernameController = TextEditingController();
+  final _newPasswordController = TextEditingController();
+  String? _errorMessage;
+  String? _successMessage;
+  String? _tempPassword;
+  bool _showNewPasswordField = false;
+
+  void _checkUsername() {
+    final appState = Provider.of<AppState>(context, listen: false);
+    final username = _usernameController.text.trim();
+    
+    if (username.isEmpty) {
+      setState(() {
+        _errorMessage = 'Please enter a username';
+        _successMessage = null;
+      });
+      return;
+    }
+
+    if (appState.userExists(username)) {
+      // Generate a temporary password for demonstration
+      final tempPassword = 'temp${DateTime.now().millisecondsSinceEpoch % 10000}';
+      setState(() {
+        _errorMessage = null;
+        _tempPassword = tempPassword;
+        _showNewPasswordField = true;
+        _successMessage = 'Username found! Your temporary password is: $tempPassword\nYou can also set a new password below.';
+      });
+    } else {
+      setState(() {
+        _errorMessage = 'Username not found';
+        _successMessage = null;
+        _tempPassword = null;
+        _showNewPasswordField = false;
+      });
+    }
+  }
+
+  void _resetPassword() {
+    final appState = Provider.of<AppState>(context, listen: false);
+    final username = _usernameController.text.trim();
+    String newPassword;
+
+    if (_newPasswordController.text.trim().isNotEmpty) {
+      newPassword = _newPasswordController.text.trim();
+    } else if (_tempPassword != null) {
+      newPassword = _tempPassword!;
+    } else {
+      setState(() {
+        _errorMessage = 'Please enter a new password or use the temporary password';
+      });
+      return;
+    }
+
+    final success = appState.resetPassword(username, newPassword);
+    
+    if (success) {
+      // Show success dialog and navigate back to login
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Password Reset Successful'),
+          content: const Text('Your password has been updated. You can now log in with your new password.'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(); // Close dialog
+                Navigator.of(context).pop(); // Go back to login screen
+              },
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    } else {
+      setState(() {
+        _errorMessage = 'Failed to reset password. Please try again.';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appState = Provider.of<AppState>(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Reset Password'),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: Icon(
+              appState.isDarkMode ? Icons.light_mode : Icons.dark_mode,
+            ),
+            onPressed: () {
+              appState.toggleTheme();
+            },
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text(
+              'Enter your username to reset your password',
+              style: TextStyle(fontSize: 16),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            TextField(
+              controller: _usernameController,
+              decoration: const InputDecoration(
+                labelText: 'Username',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _checkUsername,
+              child: const Text('Check Username'),
+            ),
+            if (_showNewPasswordField) ...[
+              const SizedBox(height: 24),
+              TextField(
+                controller: _newPasswordController,
+                decoration: const InputDecoration(
+                  labelText: 'New Password (optional)',
+                  border: OutlineInputBorder(),
+                  hintText: 'Leave empty to use temporary password',
+                ),
+                obscureText: true,
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _resetPassword,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.green,
+                ),
+                child: const Text('Reset Password'),
+              ),
+            ],
+            if (_errorMessage != null) ...[
+              const SizedBox(height: 16),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.red.shade50,
+                  border: Border.all(color: Colors.red),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  _errorMessage!,
+                  style: const TextStyle(color: Colors.red),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+            if (_successMessage != null) ...[
+              const SizedBox(height: 16),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.green.shade50,
+                  border: Border.all(color: Colors.green),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  _successMessage!,
+                  style: const TextStyle(color: Colors.green),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+            const SizedBox(height: 24),
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              child: const Text('Back to Login'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/password_reset_screen.dart
+++ b/lib/screens/password_reset_screen.dart
@@ -12,13 +12,22 @@ class PasswordResetScreen extends StatefulWidget {
 class _PasswordResetScreenState extends State<PasswordResetScreen> {
   final _usernameController = TextEditingController();
   final _newPasswordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
   String? _errorMessage;
   String? _successMessage;
   String? _tempPassword;
-  bool _showNewPasswordField = false;
+  bool _showPasswordFields = false;
+  bool _isLoading = false;
 
-  void _checkUsername() {
-    final appState = Provider.of<AppState>(context, listen: false);
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _newPasswordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  void _checkUsername() async {
     final username = _usernameController.text.trim();
     
     if (username.isEmpty) {
@@ -29,61 +38,99 @@ class _PasswordResetScreenState extends State<PasswordResetScreen> {
       return;
     }
 
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+      _successMessage = null;
+    });
+
+    // Simulate network delay for realistic UX
+    await Future.delayed(const Duration(milliseconds: 500));
+
+    final appState = Provider.of<AppState>(context, listen: false);
+    
     if (appState.userExists(username)) {
       // Generate a temporary password for demonstration
       final tempPassword = 'temp${DateTime.now().millisecondsSinceEpoch % 10000}';
       setState(() {
-        _errorMessage = null;
+        _isLoading = false;
         _tempPassword = tempPassword;
-        _showNewPasswordField = true;
-        _successMessage = 'Username found! Your temporary password is: $tempPassword\nYou can also set a new password below.';
+        _showPasswordFields = true;
+        _successMessage = 'Username found! Your temporary password is: $tempPassword\n\nYou can use this temporary password or set a new one below.';
       });
     } else {
       setState(() {
+        _isLoading = false;
         _errorMessage = 'Username not found';
-        _successMessage = null;
+        _showPasswordFields = false;
         _tempPassword = null;
-        _showNewPasswordField = false;
       });
     }
   }
 
-  void _resetPassword() {
-    final appState = Provider.of<AppState>(context, listen: false);
+  void _resetPassword() async {
     final username = _usernameController.text.trim();
-    String newPassword;
+    final newPassword = _newPasswordController.text.trim();
+    final confirmPassword = _confirmPasswordController.text.trim();
 
-    if (_newPasswordController.text.trim().isNotEmpty) {
-      newPassword = _newPasswordController.text.trim();
-    } else if (_tempPassword != null) {
-      newPassword = _tempPassword!;
-    } else {
+    // Validate password inputs
+    if (newPassword.isEmpty) {
       setState(() {
         _errorMessage = 'Please enter a new password or use the temporary password';
       });
       return;
     }
 
+    if (newPassword != confirmPassword) {
+      setState(() {
+        _errorMessage = 'Passwords do not match';
+      });
+      return;
+    }
+
+    if (newPassword.length < 6) {
+      setState(() {
+        _errorMessage = 'Password must be at least 6 characters long';
+      });
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    // Simulate network delay
+    await Future.delayed(const Duration(milliseconds: 500));
+
+    final appState = Provider.of<AppState>(context, listen: false);
     final success = appState.resetPassword(username, newPassword);
     
+    setState(() {
+      _isLoading = false;
+    });
+
     if (success) {
       // Show success dialog and navigate back to login
-      showDialog(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('Password Reset Successful'),
-          content: const Text('Your password has been updated. You can now log in with your new password.'),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop(); // Close dialog
-                Navigator.of(context).pop(); // Go back to login screen
-              },
-              child: const Text('OK'),
-            ),
-          ],
-        ),
-      );
+      if (mounted) {
+        showDialog(
+          context: context,
+          barrierDismissible: false,
+          builder: (context) => AlertDialog(
+            title: const Text('Password Reset Successful'),
+            content: const Text('Your password has been updated successfully. You can now log in with your new password.'),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).pop(); // Close dialog
+                  Navigator.of(context).pop(); // Go back to login screen
+                },
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+      }
     } else {
       setState(() {
         _errorMessage = 'Failed to reset password. Please try again.';
@@ -91,9 +138,17 @@ class _PasswordResetScreenState extends State<PasswordResetScreen> {
     }
   }
 
+  void _useTempPassword() {
+    if (_tempPassword != null) {
+      _newPasswordController.text = _tempPassword!;
+      _confirmPasswordController.text = _tempPassword!;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final appState = Provider.of<AppState>(context);
+    
     return Scaffold(
       appBar: AppBar(
         title: const Text('Reset Password'),
@@ -113,45 +168,106 @@ class _PasswordResetScreenState extends State<PasswordResetScreen> {
         padding: const EdgeInsets.all(16.0),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            const Text(
-              'Enter your username to reset your password',
-              style: TextStyle(fontSize: 16),
-              textAlign: TextAlign.center,
+            const Icon(
+              Icons.lock_reset,
+              size: 64,
+              color: Colors.blue,
             ),
             const SizedBox(height: 24),
+            const Text(
+              'Reset Your Password',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Enter your username to reset your password',
+              style: TextStyle(fontSize: 16, color: Colors.grey),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 32),
+            
+            // Username field
             TextField(
               controller: _usernameController,
               decoration: const InputDecoration(
                 labelText: 'Username',
                 border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.person),
               ),
+              enabled: !_isLoading,
             ),
             const SizedBox(height: 16),
+            
+            // Check username button
             ElevatedButton(
-              onPressed: _checkUsername,
-              child: const Text('Check Username'),
+              onPressed: _isLoading ? null : _checkUsername,
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+              ),
+              child: _isLoading 
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Check Username'),
             ),
-            if (_showNewPasswordField) ...[
+            
+            // Password fields (shown after username is verified)
+            if (_showPasswordFields) ...[
               const SizedBox(height: 24),
+              const Divider(),
+              const SizedBox(height: 16),
               TextField(
                 controller: _newPasswordController,
                 decoration: const InputDecoration(
-                  labelText: 'New Password (optional)',
+                  labelText: 'New Password',
                   border: OutlineInputBorder(),
-                  hintText: 'Leave empty to use temporary password',
+                  prefixIcon: Icon(Icons.lock),
                 ),
                 obscureText: true,
+                enabled: !_isLoading,
               ),
               const SizedBox(height: 16),
+              TextField(
+                controller: _confirmPasswordController,
+                decoration: const InputDecoration(
+                  labelText: 'Confirm New Password',
+                  border: OutlineInputBorder(),
+                  prefixIcon: Icon(Icons.lock_outline),
+                ),
+                obscureText: true,
+                enabled: !_isLoading,
+              ),
+              if (_tempPassword != null) ...[
+                const SizedBox(height: 12),
+                TextButton.icon(
+                  onPressed: _isLoading ? null : _useTempPassword,
+                  icon: const Icon(Icons.content_copy, size: 16),
+                  label: const Text('Use Temporary Password'),
+                ),
+              ],
+              const SizedBox(height: 16),
               ElevatedButton(
-                onPressed: _resetPassword,
+                onPressed: _isLoading ? null : _resetPassword,
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.green,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
                 ),
-                child: const Text('Reset Password'),
+                child: _isLoading 
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                    )
+                  : const Text('Reset Password'),
               ),
             ],
+            
+            // Error message
             if (_errorMessage != null) ...[
               const SizedBox(height: 16),
               Container(
@@ -161,13 +277,22 @@ class _PasswordResetScreenState extends State<PasswordResetScreen> {
                   border: Border.all(color: Colors.red),
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: Text(
-                  _errorMessage!,
-                  style: const TextStyle(color: Colors.red),
-                  textAlign: TextAlign.center,
+                child: Row(
+                  children: [
+                    const Icon(Icons.error_outline, color: Colors.red),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        _errorMessage!,
+                        style: const TextStyle(color: Colors.red),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],
+            
+            // Success message
             if (_successMessage != null) ...[
               const SizedBox(height: 16),
               Container(
@@ -177,13 +302,22 @@ class _PasswordResetScreenState extends State<PasswordResetScreen> {
                   border: Border.all(color: Colors.green),
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: Text(
-                  _successMessage!,
-                  style: const TextStyle(color: Colors.green),
-                  textAlign: TextAlign.center,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Icon(Icons.check_circle_outline, color: Colors.green),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        _successMessage!,
+                        style: const TextStyle(color: Colors.green),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],
+            
             const SizedBox(height: 24),
             TextButton(
               onPressed: () {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add a mock password reset feature to the login flow, allowing users to update their password locally.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This implements a mock password reset process, including a "Forgot Password" link on the login screen, a dedicated reset form, username validation against local storage, and local password updates within the `AppState`.

---
<a href="https://cursor.com/background-agent?bcId=bc-545c47af-febe-43ad-936b-4ac7e9ae416f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-545c47af-febe-43ad-936b-4ac7e9ae416f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>